### PR TITLE
Enable htpasswd access controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/OpenZeppelin/disco/drivers/ipfs"
 	"github.com/OpenZeppelin/disco/proxy"
 	"github.com/distribution/distribution/v3/registry"
+	_ "github.com/distribution/distribution/v3/registry/auth/htpasswd"
 )
 
 func main() {


### PR DESCRIPTION
Small change to enable htpasswd access controller registration

Now it is possible to configure htpasswd authentication by adding this:
```yaml
auth:
  htpasswd:
      realm: <anything>
      path: <path_to_file>
```

It supports only bcrypt format and it is possible to generate a file by using the `htpasswd` CLI like this:
```
$ htpasswd -cbB .discopass discouser discopass
Adding password for user discouser
$ cat .discopass
discouser:$2y$05$s9Cv5qlXbp/qKZJ0ZwRo1Olhq.IIehrmqQbb6F1whQQvTzUK/CA06
```

After enabling this in the config, the users need to do `docker login <disco_host>` and enter the username and password (or use the `-p` and `-u` flags to provide).