### PR TITLE
Fix nil pointer because of not specified default driver with nil config

### DIFF
--- a/drivers/ipfs/driver.go
+++ b/drivers/ipfs/driver.go
@@ -47,6 +47,7 @@ func (df *driverFactory) Create(parameters map[string]interface{}) (storagedrive
 		return nil, fmt.Errorf("failed to create ipfs driver: %v", err)
 	}
 	if config.Cache == nil {
+		defaultDriver = ipfsDriver
 		return ipfsDriver, nil
 	}
 	// create multidriver by using cache as secondary


### PR DESCRIPTION
With default config panic is going to happen if you gonna try to push any image:

```
2023/11/27 11:09:22 http: panic serving [::1]:55500: runtime error: invalid memory address or nil pointer dereference
goroutine 150 [running]:
net/http.(*conn).serve.func1()
        /usr/lib/go/src/net/http/server.go:1868 +0xb9
panic({0xd745c0?, 0x1773e70?})
        /usr/lib/go/src/runtime/panic.go:920 +0x270
github.com/forta-network/disco/proxy/services.(*Disco).MakeGlobalRepo.func1()
        /home/dkeysil/code/forta/disco/proxy/services/disco.go:84 +0x26
panic({0xd745c0?, 0x1773e70?})
        /usr/lib/go/src/runtime/panic.go:920 +0x270
github.com/forta-network/disco/proxy/services.(*Disco).MakeGlobalRepo(0xc000119720, {0x11ab300, 0xc00017eeb0}, {0xc000046ba8, 0x8})
        /home/dkeysil/code/forta/disco/proxy/services/disco.go:116 +0x65e
github.com/forta-network/disco/proxy.postHandle({0xc0000a6e10?, 0x11a8f40?}, 0xc0004a4700, 0xc0004a4700?)
        /home/dkeysil/code/forta/disco/proxy/proxy.go:74 +0x10a
github.com/forta-network/disco/proxy.New.newHandler.func2({0x11a8f40, 0xc0005aad20}, 0xc0003ec740?)
        /home/dkeysil/code/forta/disco/proxy/proxy.go:45 +0x70
net/http.HandlerFunc.ServeHTTP(0x412285?, {0x11a8f40?, 0xc0005aad20?}, 0xc0005aad01?)
        /usr/lib/go/src/net/http/server.go:2136 +0x29
net/http.serverHandler.ServeHTTP({0x11a5888?}, {0x11a8f40?, 0xc0005aad20?}, 0x6?)
        /usr/lib/go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc0003853b0, {0x11ab2c8, 0xc0000231d0})
        /usr/lib/go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 1
        /usr/lib/go/src/net/http/server.go:3086 +0x5cb
```